### PR TITLE
Add MeanFlow one-step generation training

### DIFF
--- a/src/nanodiffusion/meanflow/__init__.py
+++ b/src/nanodiffusion/meanflow/__init__.py
@@ -1,0 +1,1 @@
+from .meanflow import MeanFlowModelWrapper, compute_meanflow_loss, sample_t_r, generate_samples_meanflow

--- a/src/nanodiffusion/meanflow/meanflow.py
+++ b/src/nanodiffusion/meanflow/meanflow.py
@@ -1,0 +1,308 @@
+"""
+MeanFlow: One-step generation via average velocity field learning.
+
+Implements the MeanFlow framework from "Mean Flows for One-step Generative Modeling"
+(Geng et al., NeurIPS 2025). Instead of learning instantaneous velocity v_t(x_t) as in
+standard flow matching, MeanFlow learns the average velocity u(z_t, r, t) over an
+interval [r, t], enabling one-step generation: x_0 = z_1 - u(z_1, r=0, t=1).
+
+Key components:
+1. MeanFlowModelWrapper: wraps existing models (DiT, UNet, TLD) to condition on
+   both t and delta=t-r via a second time embedder.
+2. MeanFlow Identity: u = v - (t-r) * du/dt, used as a self-supervised training signal.
+3. JVP computation: efficiently computes the total time derivative du/dt.
+4. Adaptive L2 loss: down-weights easy examples for stable training.
+
+References:
+- https://arxiv.org/abs/2505.13447
+- https://arxiv.org/abs/2511.23342
+"""
+
+import math
+from functools import partial
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+class MeanFlowModelWrapper(nn.Module):
+    """Wraps an existing denoising model to support MeanFlow's (z, t, r) interface.
+
+    Adds a parallel time embedder for delta=t-r. The delta embedding is summed with
+    the base model's time embedding to produce a combined conditioning vector.
+    Supports DiT, UNet, and TLD architectures.
+    """
+
+    def __init__(self, base_model):
+        super().__init__()
+        self.model = base_model
+        self._model_type = self._detect_type()
+        self._build_delta_embedder()
+
+    def _detect_type(self):
+        cls_name = type(self.model).__name__
+        if cls_name == "DiT":
+            return "dit"
+        elif cls_name == "UNetModel":
+            return "unet"
+        elif cls_name == "Denoiser":
+            return "tld"
+        raise ValueError(f"Unsupported model type: {cls_name}")
+
+    def _build_delta_embedder(self):
+        if self._model_type == "dit":
+            hidden_size = self.model.t_embedder.mlp[-1].out_features
+            freq_size = self.model.t_embedder.frequency_embedding_size
+            self.delta_embedder = _TimestepEmbedder(hidden_size, freq_size)
+        elif self._model_type == "unet":
+            mc = self.model.model_channels
+            ted = self.model.time_embed[-1].out_features
+            self.delta_embedder = nn.Sequential(
+                nn.Linear(mc, ted), nn.SiLU(), nn.Linear(ted, ted)
+            )
+            self._unet_mc = mc
+        elif self._model_type == "tld":
+            ed = self.model.embed_dim
+            ned = self.model.noise_embed_dims
+            self.delta_feats = nn.Sequential(
+                _SinusoidalEmbedding(embedding_dims=ned),
+                nn.Linear(ned, ed), nn.GELU(), nn.Linear(ed, ed),
+            )
+
+    def forward(self, z, t, r, y=None):
+        delta = t - r
+        if self._model_type == "dit":
+            return self._forward_dit(z, t, delta, y)
+        elif self._model_type == "unet":
+            return self._forward_unet(z, t, delta, y)
+        elif self._model_type == "tld":
+            return self._forward_tld(z, t, delta, y)
+
+    def _forward_dit(self, z, t, delta, y):
+        m = self.model
+        x = m.x_embedder(z) + m.pos_embed
+        c = m.t_embedder(t) + self.delta_embedder(delta)
+        if y is not None:
+            c = c + m.cond_proj(y)
+        for block in m.blocks:
+            x = block(x, c)
+        x = m.final_layer(x, c)
+        x = m.unpatchify(x)
+        return x
+
+    def _forward_unet(self, z, t, delta, y):
+        m = self.model
+        emb = m.time_embed(_timestep_embedding(t, m.model_channels))
+        emb = emb + self.delta_embedder(_timestep_embedding(delta, self._unet_mc))
+        if y is not None:
+            emb = emb + m.cond_proj(y)
+        h = z.type(m.dtype)
+        hs = []
+        for module in m.input_blocks:
+            h = module(h, emb)
+            hs.append(h)
+        h = m.middle_block(h, emb)
+        for module in m.output_blocks:
+            h = torch.cat([h, hs.pop()], dim=1)
+            h = module(h, emb)
+        h = h.type(z.dtype)
+        return m.out(h)
+
+    def _forward_tld(self, z, t, delta, y):
+        m = self.model
+        if t.ndim == 1:
+            t = t[:, None].float()
+            delta = delta[:, None].float()
+        t_emb = m.fourier_feats(t).unsqueeze(1)
+        delta_emb = self.delta_feats(delta).unsqueeze(1)
+        if y is not None:
+            y_emb = m.label_proj(y).unsqueeze(1)
+        else:
+            y_emb = torch.zeros_like(t_emb)
+        cond = torch.cat([t_emb + delta_emb, y_emb], dim=1)
+        cond = m.norm(cond)
+        return m.denoiser_trans_block(z, cond)
+
+
+# --- Time sampling ---
+
+def sample_t_r(batch_size, device, flow_ratio=0.5, dist="lognorm", mu=-0.4, sigma=1.0):
+    """Sample (t, r) pairs for MeanFlow training.
+
+    Args:
+        flow_ratio: fraction of samples where r=t (instantaneous velocity).
+        dist: "lognorm" for logit-normal or "uniform".
+        mu, sigma: logit-normal distribution parameters.
+
+    Returns:
+        t, r: tensors of shape (batch_size,) with 0 < r <= t < 1.
+    """
+    if dist == "lognorm":
+        normal_samples = np.random.randn(batch_size, 2).astype(np.float32) * sigma + mu
+        samples = 1.0 / (1.0 + np.exp(-normal_samples))  # sigmoid
+    else:
+        samples = np.random.rand(batch_size, 2).astype(np.float32)
+
+    t_np = np.maximum(samples[:, 0], samples[:, 1])
+    r_np = np.minimum(samples[:, 0], samples[:, 1])
+
+    # For flow_ratio fraction, set r = t (instantaneous velocity learning)
+    num_flow = int(flow_ratio * batch_size)
+    indices = np.random.permutation(batch_size)[:num_flow]
+    r_np[indices] = t_np[indices]
+
+    return torch.tensor(t_np, device=device), torch.tensor(r_np, device=device)
+
+
+# --- Loss computation ---
+
+def adaptive_l2_loss(error, gamma=0.5, c=1e-3):
+    """Adaptive L2 loss: sg(w) * ||delta||^2 where w = 1/(||delta||^2 + c)^p."""
+    delta_sq = torch.mean(error ** 2, dim=list(range(1, error.ndim)))
+    p = 1.0 - gamma
+    w = 1.0 / (delta_sq + c).pow(p)
+    return (w.detach() * delta_sq).mean()
+
+
+def compute_meanflow_loss(model, x, device, flow_ratio=0.5, time_dist="lognorm",
+                          time_mu=-0.4, time_sigma=1.0, gamma=0.5):
+    """Compute MeanFlow training loss using the MeanFlow identity and JVP.
+
+    The MeanFlow identity: u(z_t, r, t) = v(z_t, t) - (t-r) * d/dt u(z_t, r, t)
+    Target: u_tgt = v - (t-r) * dudt, where dudt is computed via JVP.
+
+    Args:
+        model: MeanFlowModelWrapper that takes (z, t, r).
+        x: clean data batch, shape (B, C, H, W), assumed normalized to [-1, 1].
+        device: torch device.
+        flow_ratio: fraction of samples with r=t.
+        time_dist: time sampling distribution.
+        time_mu, time_sigma: logit-normal parameters.
+        gamma: adaptive loss power (0.5 = default from paper).
+
+    Returns:
+        loss: scalar training loss.
+        mse: scalar MSE for logging (detached).
+    """
+    batch_size = x.shape[0]
+    t, r = sample_t_r(batch_size, device, flow_ratio, time_dist, time_mu, time_sigma)
+
+    t_ = t.view(-1, 1, 1, 1)
+    r_ = r.view(-1, 1, 1, 1)
+
+    e = torch.randn_like(x)
+    z = (1 - t_) * x + t_ * e  # noisy sample on the flow path
+    v = e - x  # ground truth instantaneous velocity
+
+    # Compute u and du/dt via JVP (forward-mode AD).
+    # Tangent vectors: dz/dt = v, dt/dt = 1, dr/dt = 0
+    # This computes the total time derivative of u along the flow trajectory.
+    # We disable flash/efficient SDPA backends because they don't support
+    # the higher-order gradients required by JVP.
+    fn = partial(_model_fn, model=model)
+    tangents = (v, torch.ones_like(t), torch.zeros_like(r))
+
+    with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.MATH):
+        u, dudt = torch.autograd.functional.jvp(
+            fn, (z, t, r), tangents, create_graph=True,
+        )
+
+    # MeanFlow target: u_tgt = v - (t-r) * dudt
+    u_tgt = v - (t_ - r_) * dudt
+
+    error = u - u_tgt.detach()
+    loss = adaptive_l2_loss(error, gamma=gamma)
+    mse = (error.detach() ** 2).mean()
+
+    return loss, mse
+
+
+def _model_fn(z, t, r, model):
+    """Thin wrapper for JVP: calls model(z, t, r)."""
+    return model(z, t, r)
+
+
+# --- Sampling ---
+
+@torch.no_grad()
+def generate_samples_meanflow(model, device, num_samples=8, resolution=32,
+                              in_channels=3, sample_steps=1, seed=0):
+    """Generate samples using MeanFlow's average velocity field.
+
+    For one-step generation (sample_steps=1): x = z - u(z, r=0, t=1).
+    For multi-step: iteratively apply z_r = z_t - (t-r) * u(z_t, r, t).
+
+    Args:
+        model: MeanFlowModelWrapper.
+        sample_steps: number of sampling steps (1 for one-step generation).
+    """
+    model.eval()
+    torch.manual_seed(seed)
+
+    z = torch.randn(num_samples, in_channels, resolution, resolution, device=device)
+    t_vals = torch.linspace(1.0, 0.0, sample_steps + 1, device=device)
+
+    for i in range(sample_steps):
+        t = torch.full((num_samples,), t_vals[i], device=device)
+        r = torch.full((num_samples,), t_vals[i + 1], device=device)
+        t_ = t.view(-1, 1, 1, 1)
+        r_ = r.view(-1, 1, 1, 1)
+        u = model(z, t, r)
+        z = z - (t_ - r_) * u
+
+    z = z.clip(-1, 1)
+    z = z / 2 + 0.5  # denormalize to [0, 1]
+    return z
+
+
+# --- Helper modules ---
+
+def _timestep_embedding(timesteps, dim, max_period=10000):
+    """Sinusoidal timestep embedding (matches UNet implementation)."""
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+    ).to(device=timesteps.device)
+    args = timesteps[:, None].float() * freqs[None]
+    return torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+
+
+class _SinusoidalEmbedding(nn.Module):
+    """Sinusoidal embedding for TLD compatibility."""
+    def __init__(self, emb_min_freq=1.0, emb_max_freq=1000.0, embedding_dims=32):
+        super().__init__()
+        frequencies = torch.exp(
+            torch.linspace(np.log(emb_min_freq), np.log(emb_max_freq), embedding_dims // 2)
+        )
+        self.register_buffer("angular_speeds", 2.0 * torch.pi * frequencies)
+
+    def forward(self, x):
+        return torch.cat(
+            [torch.sin(self.angular_speeds * x), torch.cos(self.angular_speeds * x)], dim=-1
+        )
+
+
+class _TimestepEmbedder(nn.Module):
+    """Timestep embedder for DiT compatibility."""
+    def __init__(self, hidden_size, frequency_embedding_size=256):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+        self.frequency_embedding_size = frequency_embedding_size
+
+    def forward(self, t):
+        half = self.frequency_embedding_size // 2
+        freqs = torch.exp(
+            -math.log(10000) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+        ).to(device=t.device)
+        if t.dim() == 0:
+            t = t.unsqueeze(0)
+        args = t[:, None].float() * freqs[None]
+        t_freq = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if self.frequency_embedding_size % 2:
+            t_freq = torch.cat([t_freq, torch.zeros_like(t_freq[:, :1])], dim=-1)
+        return self.mlp(t_freq)

--- a/src/train_meanflow.py
+++ b/src/train_meanflow.py
@@ -1,0 +1,413 @@
+"""
+MeanFlow training pipeline for one-step image generation.
+
+MeanFlow learns an average velocity field u(z_t, r, t) instead of an instantaneous
+velocity v_t(z_t). At inference, a single forward pass generates images:
+    x_0 = z_1 - u(z_1, r=0, t=1)   where z_1 ~ N(0, I)
+
+The training signal comes from the MeanFlow identity:
+    u = v - (t-r) * du/dt
+computed efficiently using Jacobian-vector products (JVP).
+
+Usage:
+    python src/train_meanflow.py -d cifar10 --net dit_t1 --resolution 32
+    python src/train_meanflow.py -d cifar10 --net unet_small --resolution 32 --sample_steps 5
+
+References:
+    - "Mean Flows for One-step Generative Modeling" (Geng et al., 2025)
+    - https://arxiv.org/abs/2505.13447
+"""
+
+import argparse
+import copy
+import os
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Any
+
+import torch
+import torch.optim as optim
+from torch.nn import Module
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+from torchvision.utils import save_image, make_grid
+
+try:
+    import wandb
+except ImportError:
+    print("wandb not installed, skipping")
+
+try:
+    from cleanfid import fid
+except ImportError:
+    print("clean-fid not installed, skipping")
+
+from nanodiffusion.meanflow import (
+    MeanFlowModelWrapper,
+    compute_meanflow_loss,
+    generate_samples_meanflow,
+)
+from nanodiffusion.models.factory import create_model, choices
+from nanodiffusion.optimizers.lr_schedule import get_cosine_schedule_with_warmup
+from nanodiffusion.datasets import load_data
+from nanodiffusion.bookkeeping.cfm_bookkeeping import (
+    log_training_step,
+    compute_fid,
+    save_model,
+)
+from nanodiffusion.cfm.cfm_training_loop import (
+    update_ema_model,
+    save_final_models,
+    save_model,
+    precompute_fid_stats_for_real_images,
+)
+from nanodiffusion.bookkeeping.wandb_utils import load_model_from_wandb
+
+
+@dataclass
+class MeanFlowTrainingConfig:
+    # Dataset
+    dataset: str
+    resolution: int
+    val_split: float = 0.1
+    in_channels: int = 3
+
+    # Model architecture
+    net: str = "dit_t1"
+
+    # MeanFlow-specific
+    flow_ratio: float = 0.5  # fraction of samples where r=t (instantaneous velocity)
+    time_dist: str = "lognorm"  # "lognorm" or "uniform"
+    time_mu: float = -0.4  # logit-normal mean
+    time_sigma: float = 1.0  # logit-normal std
+    adaptive_loss_gamma: float = 0.5  # adaptive loss power
+    sample_steps: int = 1  # sampling steps (1 = one-step generation)
+
+    # Training loop and optimizer
+    total_steps: int = 100000
+    batch_size: int = 128
+    learning_rate: float = 1e-4
+    weight_decay: float = 0.0
+    lr_min: float = 1e-6
+    warmup_steps: int = 1000
+    max_grad_norm: float = 1.0
+
+    # EMA
+    use_ema: bool = False
+    ema_beta: float = 0.9999
+
+    # Logging and evaluation
+    log_every: int = 100
+    sample_every: int = 1000
+    save_every: int = 50000
+    validate_every: int = 10000
+    fid_every: int = 10000
+    num_samples_for_fid: int = 1000
+    num_samples_for_logging: int = 8
+    num_real_samples_for_fid: int = 10000
+
+    # Infrastructure
+    device: str = "cuda"
+    logger: str = "wandb"
+    cache_dir: str = f"{os.path.expanduser('~')}/.cache"
+    checkpoint_dir: str = "logs/train_meanflow"
+    min_steps_for_final_save: int = 100
+    watch_model: bool = False
+    init_from_wandb_run_path: str = None
+    init_from_wandb_file: str = None
+    random_flip: bool = False
+
+    def __post_init__(self):
+        self.checkpoint_dir = (
+            f"{self.checkpoint_dir}/{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+        )
+
+
+@dataclass
+class MeanFlowModelComponents:
+    model: MeanFlowModelWrapper
+    ema_model: Optional[MeanFlowModelWrapper]
+    optimizer: Optimizer
+    lr_scheduler: Any
+    # Expose base model for saving/loading compatibility
+    denoising_model: Module = None
+
+    def __post_init__(self):
+        self.denoising_model = self.model
+
+
+def create_meanflow_model_components(config: MeanFlowTrainingConfig) -> MeanFlowModelComponents:
+    device = torch.device(config.device)
+    base_model = create_model(
+        net=config.net,
+        in_channels=config.in_channels,
+        resolution=config.resolution,
+    )
+    model = MeanFlowModelWrapper(base_model).to(device)
+
+    ema_model = copy.deepcopy(model) if config.use_ema else None
+
+    optimizer = optim.AdamW(
+        model.parameters(),
+        lr=config.learning_rate,
+        weight_decay=config.weight_decay,
+    )
+    lr_scheduler = get_cosine_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=config.warmup_steps,
+        num_training_steps=config.total_steps,
+        lr_min=config.lr_min,
+    )
+
+    if config.init_from_wandb_run_path and config.init_from_wandb_file:
+        load_model_from_wandb(
+            model, config.init_from_wandb_run_path, config.init_from_wandb_file
+        )
+
+    return MeanFlowModelComponents(model, ema_model, optimizer, lr_scheduler)
+
+
+def train_step(model, x, optimizer, config, device):
+    optimizer.zero_grad()
+    x = x.to(device)
+
+    loss, mse = compute_meanflow_loss(
+        model, x, device,
+        flow_ratio=config.flow_ratio,
+        time_dist=config.time_dist,
+        time_mu=config.time_mu,
+        time_sigma=config.time_sigma,
+        gamma=config.adaptive_loss_gamma,
+    )
+
+    loss.backward()
+
+    if config.max_grad_norm > 0:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), config.max_grad_norm)
+
+    optimizer.step()
+    return loss, mse
+
+
+def generate_and_log_samples(components, config, step=None, seed=0):
+    device = torch.device(config.device)
+    model = components.model
+    n = config.num_samples_for_logging
+
+    sampled = generate_samples_meanflow(
+        model, device, n,
+        resolution=config.resolution,
+        in_channels=config.in_channels,
+        sample_steps=config.sample_steps,
+        seed=seed,
+    )
+    images = (sampled * 255).permute(0, 2, 3, 1).cpu().numpy().round().astype("uint8")
+
+    if config.logger == "wandb":
+        wandb.log({
+            "num_batches_trained": step,
+            "test_samples": [wandb.Image(img) for img in images],
+        })
+    else:
+        grid = make_grid(sampled, nrow=4, normalize=False)
+        save_image(grid, Path(config.checkpoint_dir) / f"samples_step_{step}.png")
+
+    if config.use_ema and components.ema_model is not None:
+        ema_sampled = generate_samples_meanflow(
+            components.ema_model, device, n,
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            sample_steps=config.sample_steps,
+            seed=seed,
+        )
+        ema_images = (ema_sampled * 255).permute(0, 2, 3, 1).cpu().numpy().round().astype("uint8")
+
+        if config.logger == "wandb":
+            wandb.log({
+                "num_batches_trained": step,
+                "ema_test_samples": [wandb.Image(img) for img in ema_images],
+            })
+        else:
+            grid = make_grid(ema_sampled, nrow=4, normalize=False)
+            save_image(grid, Path(config.checkpoint_dir) / f"ema_samples_step_{step}.png")
+
+
+def compute_and_log_fid(components, config):
+    device = torch.device(config.device)
+    batch_size = config.batch_size * 2
+    num_batches = (config.num_samples_for_fid + batch_size - 1) // batch_size
+    generated = []
+
+    for i in range(num_batches):
+        n = min(batch_size, config.num_samples_for_fid - len(generated))
+        batch = generate_samples_meanflow(
+            components.model, device, n,
+            resolution=config.resolution,
+            in_channels=config.in_channels,
+            sample_steps=config.sample_steps,
+            seed=i,
+        )
+        generated.append(batch)
+
+    generated = torch.cat(generated, dim=0)
+    fid_score = compute_fid(None, generated, device, config.dataset, config.resolution)
+    print(f"FID Score: {fid_score:.4f}")
+
+    log_dict = {"fid": fid_score}
+
+    if config.use_ema and components.ema_model is not None:
+        ema_generated = []
+        for i in range(num_batches):
+            n = min(batch_size, config.num_samples_for_fid - len(ema_generated))
+            batch = generate_samples_meanflow(
+                components.ema_model, device, n,
+                resolution=config.resolution,
+                in_channels=config.in_channels,
+                sample_steps=config.sample_steps,
+                seed=i,
+            )
+            ema_generated.append(batch)
+        ema_generated = torch.cat(ema_generated, dim=0)
+        ema_fid = compute_fid(None, ema_generated, device, config.dataset, config.resolution)
+        print(f"EMA FID Score: {ema_fid:.4f}")
+        log_dict["ema_fid"] = ema_fid
+
+    if config.logger == "wandb":
+        wandb.log(log_dict)
+
+
+def training_loop(components, train_dataloader, val_dataloader, config):
+    print(f"Training MeanFlow on {config.device}")
+    device = torch.device(config.device)
+    model = components.model.to(device)
+    ema_model = components.ema_model
+
+    if config.dataset not in ["cifar10"]:
+        precompute_fid_stats_for_real_images(
+            train_dataloader, config,
+            Path(config.cache_dir) / "real_images_for_fid",
+        )
+
+    if config.logger == "wandb":
+        project_name = os.getenv("WANDB_PROJECT") or "nano-diffusion"
+        print(f"Logging to W&B project: {project_name}")
+        params = sum(p.numel() for p in model.parameters())
+        run_params = asdict(config)
+        run_params["model_parameters"] = params
+        run_params["algorithm"] = "meanflow"
+        wandb.init(project=project_name, config=run_params)
+
+    checkpoint_dir = Path(config.checkpoint_dir)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    step = 0
+    num_examples = 0
+
+    while step < config.total_steps:
+        for x, _ in train_dataloader:
+            if step >= config.total_steps:
+                break
+
+            num_examples += x.shape[0]
+            x = x.to(device)
+
+            model.train()
+            loss, mse = train_step(model, x, components.optimizer, config, device)
+            model.eval()
+
+            components.lr_scheduler.step()
+
+            with torch.no_grad():
+                if config.use_ema and ema_model is not None:
+                    update_ema_model(ema_model, model, config.ema_beta)
+
+                if step % config.log_every == 0:
+                    log_training_step(step, num_examples, loss, components.optimizer, config.logger)
+                    if config.logger == "wandb":
+                        wandb.log({"mse": mse.item()})
+
+                if step % config.sample_every == 0:
+                    generate_and_log_samples(components, config, step=step, seed=0)
+
+                if step % config.save_every == 0 and step > 0:
+                    save_model(
+                        model, checkpoint_dir / f"model_step_{step}.pth", config.logger
+                    )
+                    if config.use_ema and ema_model is not None:
+                        save_model(
+                            ema_model, checkpoint_dir / f"ema_model_step_{step}.pth",
+                            config.logger,
+                        )
+
+                if step % config.fid_every == 0 and step > 0:
+                    compute_and_log_fid(components, config)
+
+            step += 1
+
+    if step > config.min_steps_for_final_save:
+        save_final_models(components, config)
+
+    return num_examples
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="MeanFlow training for one-step image generation")
+    parser.add_argument("-d", "--dataset", type=str, default="cifar10")
+    parser.add_argument("--resolution", type=int, default=32)
+    parser.add_argument("--in_channels", type=int, default=3)
+    parser.add_argument("--net", type=str, choices=choices(), default="dit_t1")
+
+    # MeanFlow-specific
+    parser.add_argument("--flow_ratio", type=float, default=0.5,
+                        help="Fraction of samples with r=t (instantaneous velocity learning)")
+    parser.add_argument("--time_dist", type=str, choices=["lognorm", "uniform"], default="lognorm")
+    parser.add_argument("--time_mu", type=float, default=-0.4, help="Logit-normal mean")
+    parser.add_argument("--time_sigma", type=float, default=1.0, help="Logit-normal std")
+    parser.add_argument("--adaptive_loss_gamma", type=float, default=0.5)
+    parser.add_argument("--sample_steps", type=int, default=1,
+                        help="Sampling steps (1 = one-step generation)")
+
+    # Training
+    parser.add_argument("--total_steps", type=int, default=100000)
+    parser.add_argument("--batch_size", type=int, default=32)
+    parser.add_argument("--learning_rate", type=float, default=1e-4)
+    parser.add_argument("--weight_decay", type=float, default=1e-6)
+    parser.add_argument("--lr_min", type=float, default=2e-6)
+    parser.add_argument("--warmup_steps", type=int, default=1000)
+    parser.add_argument("--max_grad_norm", type=float, default=1.0)
+    parser.add_argument("--use_ema", action="store_true")
+    parser.add_argument("--ema_beta", type=float, default=0.9999)
+
+    # Logging
+    parser.add_argument("--logger", type=str, choices=["wandb", "none"], default="none")
+    parser.add_argument("--log_every", type=int, default=100)
+    parser.add_argument("--sample_every", type=int, default=1500)
+    parser.add_argument("--save_every", type=int, default=60000)
+    parser.add_argument("--validate_every", type=int, default=1500)
+    parser.add_argument("--fid_every", type=int, default=6000)
+    parser.add_argument("--num_samples_for_fid", type=int, default=1000)
+    parser.add_argument("--num_samples_for_logging", type=int, default=8)
+    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument("--checkpoint_dir", type=str, default="logs/train_meanflow")
+    parser.add_argument("--random_flip", action="store_true")
+    parser.add_argument("--watch_model", action="store_true")
+    parser.add_argument("--init_from_wandb_run_path", type=str, default=None)
+    parser.add_argument("--init_from_wandb_file", type=str, default=None)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    config = MeanFlowTrainingConfig(**vars(args))
+
+    train_dataloader, val_dataloader = load_data(config)
+    components = create_meanflow_model_components(config)
+
+    num_examples = training_loop(components, train_dataloader, val_dataloader, config)
+    print(f"Training completed. Total examples trained: {num_examples}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Implement MeanFlow (Geng et al., NeurIPS 2025) for one-step image generation without distillation
- Add `MeanFlowModelWrapper` that wraps DiT/UNet/TLD models with a delta-time embedder for (z, t, r) conditioning
- Implement MeanFlow loss with JVP computation for the MeanFlow identity: u = v - (t-r) * du/dt
- Add adaptive L2 loss with logit-normal time sampling
- Support both one-step and multi-step sampling via average velocity field
- Create `src/train_meanflow.py` entry point with full training pipeline

## New files
- `src/nanodiffusion/meanflow/__init__.py` - Module exports
- `src/nanodiffusion/meanflow/meanflow.py` - Core MeanFlow implementation (~250 LOC)
- `src/train_meanflow.py` - Training entry point (~300 LOC)

## Usage
```bash
# One-step generation with DiT
python src/train_meanflow.py -d cifar10 --net dit_t1 --resolution 32 --sample_steps 1

# Multi-step with UNet
python src/train_meanflow.py -d cifar10 --net unet_small --resolution 32 --sample_steps 5
```

## Test plan
- [x] DiT model: forward, loss, backward, sampling on CPU and GPU
- [x] UNet model: forward, loss, backward on CPU and GPU
- [x] TLD model: forward, loss, backward on GPU
- [x] End-to-end training loop (200 steps on CIFAR-10, loss decreasing)
- [x] One-step and multi-step sampling produce correct-shaped outputs

## References
- [Mean Flows for One-step Generative Modeling](https://arxiv.org/abs/2505.13447) (NeurIPS 2025 Oral)
- [Re-MeanFlow](https://arxiv.org/abs/2511.23342)

Closes zzsi/agent-manager#8