### PR TITLE
Add Micro-Diffusion patch masking to DiT training

### DIFF
--- a/src/nanodiffusion/config/diffusion_training_config.py
+++ b/src/nanodiffusion/config/diffusion_training_config.py
@@ -85,6 +85,12 @@ class DiffusionTrainingConfig:
     )
     init_from_wandb_file: str = None  # resume model from a wandb file "path/to/file"
 
+    # Patch masking (Micro-Diffusion)
+    mask_ratio: float = 0.0  # fraction of patches to mask during training (0.0 = no masking, 0.75 = mask 75%)
+    patch_mixer_depth: int = 0  # depth of lightweight patch-mixer for deferred masking (0 = no mixer)
+    progressive_unmasking: bool = False  # linearly decrease mask_ratio from mask_ratio to 0 over training
+    unmask_start_ratio: float = 0.5  # fraction of training at which progressive unmasking begins (only if progressive_unmasking=True)
+
     # Data augmentation
     random_flip: bool = False  # randomly flip images horizontally
 

--- a/src/nanodiffusion/diffusion/diffusion_model_components.py
+++ b/src/nanodiffusion/diffusion/diffusion_model_components.py
@@ -44,7 +44,8 @@ def create_diffusion_model_components(
     device = torch.device(config.device)
     if denoising_model is None:  # if no denoising model is provided, create one based on config.net
         denoising_model = create_model(
-            net=config.net, in_channels=config.in_channels, resolution=config.resolution, cond_embed_dim=config.cond_embed_dim
+            net=config.net, in_channels=config.in_channels, resolution=config.resolution,
+            cond_embed_dim=config.cond_embed_dim, patch_mixer_depth=config.patch_mixer_depth,
         )
     else:
         config.net = denoising_model.name if hasattr(denoising_model, "name") else denoising_model.__class__.__name__

--- a/src/nanodiffusion/diffusion/diffusion_training_loop.py
+++ b/src/nanodiffusion/diffusion/diffusion_training_loop.py
@@ -50,6 +50,11 @@ def training_loop(
     num_examples_trained = 0
     criterion = MSELoss()
 
+    if config.mask_ratio > 0:
+        print(f"Patch masking enabled: mask_ratio={config.mask_ratio}, patch_mixer_depth={config.patch_mixer_depth}")
+        if config.progressive_unmasking:
+            print(f"Progressive unmasking: will decrease mask_ratio from {config.mask_ratio} to 0 starting at step {int(config.total_steps * config.unmask_start_ratio)}")
+
     while step < config.total_steps:
         for batch in train_dataloader:
             if step >= config.total_steps:
@@ -60,7 +65,7 @@ def training_loop(
 
             denoising_model.train()
             loss = train_step(
-                batch, denoising_model, model_components.diffusion, optimizer, config, criterion, accelerator
+                batch, denoising_model, model_components.diffusion, optimizer, config, criterion, accelerator, step=step,
             )
             if config.log_grad_norm:
                 grad_norm = torch.norm(torch.stack([torch.norm(p.grad) for p in denoising_model.parameters() if p.grad is not None]), 2)
@@ -95,6 +100,20 @@ def training_loop(
     return num_examples_trained
 
 
+def get_effective_mask_ratio(config: TrainingConfig, step: int) -> float:
+    """Compute the effective mask ratio, accounting for progressive unmasking."""
+    if config.mask_ratio <= 0:
+        return 0.0
+    if not config.progressive_unmasking:
+        return config.mask_ratio
+    # Linear ramp-down from mask_ratio to 0 starting at unmask_start_ratio * total_steps
+    unmask_start = int(config.total_steps * config.unmask_start_ratio)
+    if step < unmask_start:
+        return config.mask_ratio
+    progress = (step - unmask_start) / max(1, config.total_steps - unmask_start)
+    return config.mask_ratio * (1.0 - progress)
+
+
 def train_step(
     batch: MiniBatch,  # data
     denoising_model: Module,  # model
@@ -103,6 +122,7 @@ def train_step(
     config: TrainingConfig,  # config
     criterion: Module,  # loss function
     accelerator = None,  # accelerator utility
+    step: int = 0,  # current training step (for progressive unmasking)
 ) -> torch.Tensor:
     context = accelerator.accumulate() if accelerator else nullcontext()
 
@@ -110,6 +130,12 @@ def train_step(
         optimizer.zero_grad()
         inputs, targets = diffusion.prepare_training_examples(batch)
         assert str(inputs["x"].device) == str(config.device), f"Inputs are on {inputs['x'].device}, but config is on {config.device}"
+
+        # Add mask_ratio to inputs if masking is enabled
+        mask_ratio = get_effective_mask_ratio(config, step)
+        if mask_ratio > 0:
+            inputs["mask_ratio"] = mask_ratio
+
         try:
             predictions = denoising_model(**inputs)
         except Exception as e:
@@ -117,14 +143,25 @@ def train_step(
                 if hasattr(v, "shape"):
                     print("------ ", k, v.shape)
             raise e
+
+        # Handle masked output: model returns (predictions, mask) when masking
+        mask = None
+        if isinstance(predictions, tuple):
+            predictions, mask = predictions
         predictions = predictions.sample if hasattr(predictions, "sample") else predictions
 
-        loss = criterion(predictions, targets)
+        # Compute loss: masked loss if masking is active, otherwise standard MSE
+        if mask is not None and hasattr(denoising_model, "patch_size"):
+            from ..models.patch_masking import compute_masked_loss
+            loss = compute_masked_loss(predictions, targets, mask, denoising_model.patch_size)
+        else:
+            loss = criterion(predictions, targets)
+
         if accelerator:
             accelerator.backward(loss)
         else:
             loss.backward()
-        
+
         if config.max_grad_norm > 0:
             torch.nn.utils.clip_grad_norm_(
                 denoising_model.parameters(), config.max_grad_norm

--- a/src/nanodiffusion/models/dit.py
+++ b/src/nanodiffusion/models/dit.py
@@ -179,6 +179,8 @@ class DiT(nn.Module):
         mlp_ratio=4.0,
         learn_sigma=True,
         cond_embed_dim=None,
+        patch_mixer_depth=0,
+        patch_mixer_dim=None,
     ):
         """
         # Load the processor and model
@@ -207,6 +209,30 @@ class DiT(nn.Module):
         # self.y_embedder = TextEncoder(model_name="zer0int/CLIP-GmP-ViT-L-14", hidden_dim=hidden_size)
         num_patches = self.x_embedder.num_patches
         self.pos_embed = nn.Parameter(torch.zeros(1, num_patches, hidden_size), requires_grad=False)
+
+        # Patch-mixer for deferred masking (Micro-Diffusion)
+        self.use_patch_mixer = patch_mixer_depth > 0
+        if self.use_patch_mixer:
+            mixer_dim = patch_mixer_dim or hidden_size // 2
+            self.patch_mixer_in = nn.Sequential(
+                nn.LayerNorm(hidden_size, eps=1e-6),
+                nn.Linear(hidden_size, mixer_dim),
+            )
+            self.patch_mixer_out = nn.Sequential(
+                nn.LayerNorm(mixer_dim, eps=1e-6),
+                nn.Linear(mixer_dim, hidden_size),
+            )
+            self.patch_mixer = nn.ModuleList([
+                DiTBlock(mixer_dim, max(1, num_heads // 2), mlp_ratio=mlp_ratio)
+                for _ in range(patch_mixer_depth)
+            ])
+            self.mixer_t_proj = nn.Linear(hidden_size, mixer_dim)
+
+        # Mask token for unmasking (output space)
+        self.register_buffer(
+            "mask_token_out",
+            torch.zeros(1, 1, patch_size * patch_size * self.out_channels),
+        )
 
         self.blocks = nn.ModuleList([
             DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio) for _ in range(depth)
@@ -277,13 +303,14 @@ class DiT(nn.Module):
     def get_null_cond_embed(self, batch_size: int=1):
         return self.null_cond_embed.repeat(batch_size, 1)
 
-    def forward(self, t, x, y=None, p_uncond=None, *args, **kwargs):
+    def forward(self, t, x, y=None, p_uncond=None, mask_ratio=0.0, *args, **kwargs):
         """
         Forward pass of DiT.
         t: (N,) tensor of diffusion timesteps
         x: (N, C, H, W) tensor of spatial inputs
         y: (N, D) tensor of conditioning embeddings
         p_uncond: probability of using null conditioning (classifier-free guidance)
+        mask_ratio: fraction of patches to mask (0.0 = no masking, 0.75 = mask 75%)
         """
         x = self.x_embedder(x) + self.pos_embed  # (N, T, D), where T = H * W / patch_size ** 2
         t = self.t_embedder(t)                   # (N, D)
@@ -298,11 +325,41 @@ class DiT(nn.Module):
             c = t + self.cond_proj(y)
         else:
             c = t
-            
+
+        mask = None
+        ids_restore = None
+
+        # Patch-mixer: process ALL patches before masking (deferred masking)
+        if self.use_patch_mixer:
+            x = self.patch_mixer_in(x)
+            c_mixer = self.mixer_t_proj(c)
+            for block in self.patch_mixer:
+                x = block(x, c_mixer)
+
+        # Apply patch masking
+        if mask_ratio > 0:
+            from nanodiffusion.models.patch_masking import get_mask, mask_out_tokens
+            mask_dict = get_mask(x.shape[0], x.shape[1], mask_ratio, x.device)
+            ids_restore = mask_dict["ids_restore"]
+            mask = mask_dict["mask"]
+            x = mask_out_tokens(x, mask_dict["ids_keep"])
+
+        # Project back to backbone dim after masking (saves compute)
+        if self.use_patch_mixer:
+            x = self.patch_mixer_out(x)
+
         for block in self.blocks:
-            x = block(x, c)                      # (N, T, D)
-        x = self.final_layer(x, c)                # (N, T, patch_size ** 2 * out_channels)
+            x = block(x, c)                      # (N, T', D)
+        x = self.final_layer(x, c)                # (N, T', patch_size ** 2 * out_channels)
+
+        # Unmask: restore full sequence
+        if mask_ratio > 0:
+            from nanodiffusion.models.patch_masking import unmask_tokens
+            x = unmask_tokens(x, ids_restore, self.mask_token_out)
+
         x = self.unpatchify(x)                   # (N, out_channels, H, W)
+        if mask_ratio > 0:
+            return x, mask
         return x
         # return SimpleNamespace(sample=x)  # this is to make it compatible with `diffusers`
 

--- a/src/nanodiffusion/models/factory.py
+++ b/src/nanodiffusion/models/factory.py
@@ -9,8 +9,14 @@ def choices():
         "unet_small", "unet", "unet_big", "unet_diffusers"
     ]
 
-def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, cond_embed_dim: int = None):
+def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, cond_embed_dim: int = None, patch_mixer_depth: int = 0):
     print(f"Creating model {net} with resolution {resolution} and in_channels {in_channels} and cond_embed_dim {cond_embed_dim}")
+
+    # Common kwargs for DiT models
+    dit_extra = {}
+    if patch_mixer_depth > 0:
+        dit_extra["patch_mixer_depth"] = patch_mixer_depth
+
     if net == "tld_t2":
         return TLD(
             image_size=resolution,
@@ -48,7 +54,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             cond_embed_dim=cond_embed_dim,
         )
     elif net == "dit_t0":
-        return DiT(
+        model = DiT(
             input_size=resolution,
             patch_size=2,
             in_channels=in_channels,
@@ -58,9 +64,10 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             depth=3,
             num_heads=1,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_t1":
-        return DiT(
+        model = DiT(
             input_size=resolution,
             patch_size=2,
             in_channels=in_channels,
@@ -70,9 +77,10 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             depth=3,
             num_heads=6,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_t2":
-        return DiT(
+        model = DiT(
             input_size=resolution,
             patch_size=2,
             in_channels=in_channels,
@@ -82,6 +90,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             depth=12,
             num_heads=1,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_t3":
         model = DiT(
@@ -94,6 +103,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
                 depth=12,
                 num_heads=6,
                 cond_embed_dim=cond_embed_dim,
+                **dit_extra,
             )
     elif net == "dit_s2":
         model = DiT(
@@ -105,6 +115,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             num_heads=6,
             learn_sigma=False,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_b2":
         model = DiT(
@@ -116,6 +127,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             num_heads=12,
             learn_sigma=False,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_b4":
         model = DiT(
@@ -127,6 +139,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             num_heads=12,
             learn_sigma=False,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_l2":
         model = DiT(
@@ -138,6 +151,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             num_heads=16,
             learn_sigma=False,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "dit_l4":
         model = DiT(
@@ -149,6 +163,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
             num_heads=16,
             learn_sigma=False,
             cond_embed_dim=cond_embed_dim,
+            **dit_extra,
         )
     elif net == "unet_small":
         model = UNetSmall(
@@ -174,7 +189,7 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
     elif net == "unet_diffusers":
         if cond_embed_dim is not None:
             raise ValueError("diffusers UNet does not support conditional models")
-        
+
         from diffusers import UNet2DModel
 
         model = UNet2DModel(
@@ -202,6 +217,6 @@ def create_model(net: str = "unet", resolution: int = 32, in_channels: int = 3, 
         )
     else:
         raise ValueError(f"Unsupported network architecture: {net}")
-    
+
     print(f"model params: {sum(p.numel() for p in model.parameters()) / 1e6:.2f} M")
     return model

--- a/src/nanodiffusion/models/patch_masking.py
+++ b/src/nanodiffusion/models/patch_masking.py
@@ -1,0 +1,118 @@
+"""
+Patch masking utilities for efficient DiT training.
+
+Based on Micro-Diffusion (Stretching Each Dollar, CVPR 2025):
+https://github.com/SonyResearch/micro_diffusion
+
+Masking 50-75% of patches during training reduces compute by 3-4x while
+maintaining generation quality, especially when combined with a lightweight
+patch-mixer that processes all patches before masking (deferred masking).
+"""
+
+import torch
+from typing import Dict
+
+
+def get_mask(batch: int, length: int, mask_ratio: float, device: torch.device) -> Dict[str, torch.Tensor]:
+    """Generate a random binary mask for patch tokens.
+
+    Parameters
+    ----------
+    batch : int
+        Batch size.
+    length : int
+        Number of patches (sequence length).
+    mask_ratio : float
+        Fraction of patches to mask (remove). E.g., 0.75 means keep 25%.
+    device : torch.device
+        Device for tensors.
+
+    Returns
+    -------
+    dict with keys:
+        mask : (N, T) binary tensor, 0 = keep, 1 = remove
+        ids_keep : (N, len_keep) indices of kept patches
+        ids_restore : (N, T) indices to unshuffle back to original order
+    """
+    len_keep = int(length * (1 - mask_ratio))
+    noise = torch.rand(batch, length, device=device)
+    ids_shuffle = torch.argsort(noise, dim=1)
+    ids_restore = torch.argsort(ids_shuffle, dim=1)
+    ids_keep = ids_shuffle[:, :len_keep]
+
+    mask = torch.ones([batch, length], device=device)
+    mask[:, :len_keep] = 0
+    mask = torch.gather(mask, dim=1, index=ids_restore)
+    return {
+        "mask": mask,
+        "ids_keep": ids_keep,
+        "ids_restore": ids_restore,
+    }
+
+
+def mask_out_tokens(x: torch.Tensor, ids_keep: torch.Tensor) -> torch.Tensor:
+    """Remove masked tokens from the sequence.
+
+    Parameters
+    ----------
+    x : (N, L, D) tensor of patch tokens
+    ids_keep : (N, len_keep) indices of tokens to keep
+
+    Returns
+    -------
+    x_masked : (N, len_keep, D) tensor with only kept tokens
+    """
+    N, L, D = x.shape
+    return torch.gather(x, dim=1, index=ids_keep.unsqueeze(-1).expand(-1, -1, D))
+
+
+def unmask_tokens(x: torch.Tensor, ids_restore: torch.Tensor, mask_token: torch.Tensor) -> torch.Tensor:
+    """Restore full sequence by inserting mask tokens at removed positions.
+
+    Parameters
+    ----------
+    x : (N, len_keep, D) tensor of processed kept tokens
+    ids_restore : (N, T) indices to restore original spatial order
+    mask_token : (1, 1, D) learned mask token to insert at removed positions
+
+    Returns
+    -------
+    x_full : (N, T, D) tensor with full sequence restored
+    """
+    num_masked = ids_restore.shape[1] - x.shape[1]
+    mask_tokens = mask_token.expand(x.shape[0], num_masked, -1)
+    x_ = torch.cat([x, mask_tokens], dim=1)
+    x_ = torch.gather(x_, dim=1, index=ids_restore.unsqueeze(-1).expand(-1, -1, x.shape[2]))
+    return x_
+
+
+def compute_masked_loss(
+    predictions: torch.Tensor,
+    targets: torch.Tensor,
+    mask: torch.Tensor,
+    patch_size: int,
+) -> torch.Tensor:
+    """Compute MSE loss only on unmasked patches.
+
+    Parameters
+    ----------
+    predictions : (N, C, H, W) predicted output
+    targets : (N, C, H, W) ground truth
+    mask : (N, num_patches) binary mask, 0 = keep, 1 = remove
+    patch_size : int
+        Spatial size of each patch.
+
+    Returns
+    -------
+    loss : scalar tensor, mean MSE over unmasked patches only
+    """
+    import torch.nn.functional as F
+
+    # Per-pixel MSE
+    loss = (predictions - targets) ** 2  # (N, C, H, W)
+    # Pool to patch level: average over channels then spatial pooling
+    loss = F.avg_pool2d(loss.mean(dim=1, keepdim=True), patch_size).flatten(1)  # (N, num_patches)
+    # Only count unmasked patches
+    unmask = 1 - mask  # 0=keep -> 1, 1=remove -> 0
+    loss = (loss * unmask).sum(dim=1) / unmask.sum(dim=1).clamp(min=1)  # (N,)
+    return loss.mean()

--- a/src/train_diffusion.py
+++ b/src/train_diffusion.py
@@ -179,6 +179,23 @@ def parse_arguments():
     parser.add_argument(
         "--random_flip", action="store_true", help="Randomly flip images horizontally"
     )
+    # Patch masking (Micro-Diffusion)
+    parser.add_argument(
+        "--mask_ratio", type=float, default=0.0,
+        help="Fraction of patches to mask during DiT training (0.0 = no masking, 0.75 = mask 75%%)",
+    )
+    parser.add_argument(
+        "--patch_mixer_depth", type=int, default=0,
+        help="Depth of lightweight patch-mixer for deferred masking (0 = no mixer)",
+    )
+    parser.add_argument(
+        "--progressive_unmasking", action="store_true",
+        help="Linearly decrease mask_ratio to 0 over training",
+    )
+    parser.add_argument(
+        "--unmask_start_ratio", type=float, default=0.5,
+        help="Fraction of training at which progressive unmasking begins",
+    )
     parser.add_argument(
         "--checkpoint_dir", type=str, default="logs/train", help="Checkpoint directory"
     )


### PR DESCRIPTION
## Summary

Adds Micro-Diffusion patch masking to the DDPM/VDM training pipeline, enabling 3-4x compute reduction during DiT training.

- **Patch masking**: Configurable 50-75% patch masking in DiT forward pass — masked patches skip the main transformer blocks
- **Deferred masking**: Optional lightweight patch-mixer processes all patches before masking, preserving spatial context (~4% compute overhead for better quality)
- **Progressive unmasking**: Linearly decrease mask_ratio to 0 over the latter half of training for clean convergence
- **Backward-compatible**: `mask_ratio=0.0` (default) = no masking, existing code unchanged

### New files
- `src/nanodiffusion/models/patch_masking.py` — Masking utilities (get_mask, mask/unmask tokens, masked loss)

### Modified files
- `src/nanodiffusion/models/dit.py` — Added patch-mixer and mask_ratio support to DiT forward pass
- `src/nanodiffusion/models/factory.py` — Added `patch_mixer_depth` parameter, fixed early-return for dit_t0/t1/t2
- `src/nanodiffusion/config/diffusion_training_config.py` — Added masking config options
- `src/nanodiffusion/diffusion/diffusion_model_components.py` — Pass `patch_mixer_depth` through to model creation
- `src/nanodiffusion/diffusion/diffusion_training_loop.py` — Handle masked training (masked loss, progressive unmasking)
- `src/train_diffusion.py` — Added CLI arguments for masking

### Usage
```bash
# DiT training with 75% patch masking (3-4x faster)
python src/train_diffusion.py -d cifar10 --net dit_s2 --mask_ratio 0.75

# With deferred masking (patch-mixer)
python src/train_diffusion.py -d cifar10 --net dit_s2 --mask_ratio 0.75 --patch_mixer_depth 4

# With progressive unmasking
python src/train_diffusion.py -d cifar10 --net dit_s2 --mask_ratio 0.75 --progressive_unmasking
```

### References
- [Stretching Each Dollar (CVPR 2025)](https://arxiv.org/abs/2407.15811)
- [SonyResearch/micro_diffusion](https://github.com/SonyResearch/micro_diffusion)

Closes #9

## Test plan
- [x] DiT forward pass without masking (backward compatibility)
- [x] DiT forward pass with masking (50%, 75%)
- [x] DiT with patch-mixer (deferred masking)
- [x] Masked loss computation
- [x] Progressive unmasking schedule
- [x] End-to-end DDPM training with masking on CIFAR-10
- [x] End-to-end training with masking + patch-mixer + progressive unmasking
- [x] UNet training unaffected (backward compatibility)