### PR TITLE
Add autoresearch framework for nano-diffusion image generation

### DIFF
--- a/src/autoresearch/README.md
+++ b/src/autoresearch/README.md
@@ -1,0 +1,70 @@
+# nano-diffusion autoresearch
+
+Automated AI research for diffusion model training — inspired by [karpathy/autoresearch](https://github.com/karpathy/autoresearch).
+
+An AI agent modifies `train.py`, runs a 5-minute training experiment on CIFAR-10, evaluates results,
+and iterates. The goal is to find the best diffusion model configuration for image generation within
+a fixed compute budget.
+
+## Quick Start
+
+```bash
+cd src/autoresearch
+
+# Prepare data (downloads CIFAR-10 to ~/.cache/torchvision)
+python prepare.py
+
+# Run baseline training (5 minutes)
+python train.py
+
+# Run without FID for faster iteration
+COMPUTE_FID=0 python train.py
+```
+
+## Structure
+
+| File | Editable | Purpose |
+|------|---------|---------|
+| `train.py` | **YES** | Model, optimizer, training loop — the agent modifies this |
+| `prepare.py` | NO | Fixed: data loading, evaluation protocol, constants |
+| `program.md` | NO | Agent instructions and research objectives |
+| `README.md` | NO | This file |
+
+## The Metric
+
+`val_loss` — MSE between predicted and true velocity on CIFAR-10 validation, averaged over 10 batches.
+Lower is better. Analogous to `val_bpb` in language model autoresearch.
+
+Secondary metric: FID (Fréchet Inception Distance). Lower is better.
+
+## Running Autoresearch
+
+Point your AI coding agent at this directory with `program.md` as context:
+
+```
+You are doing autonomous ML research. Read program.md, then:
+1. Look at the current train.py and its baseline results
+2. Propose a change
+3. Run: COMPUTE_FID=0 python train.py
+4. If val_loss improved: keep it. If not: revert.
+5. Repeat until the time budget is exhausted.
+```
+
+## Baseline
+
+| Metric | Value |
+|--------|-------|
+| val_loss | ~0.197 |
+| FID | ~65 |
+| Steps in 5 min | ~2,900 |
+| Model | DiT: hidden=192, depth=6, heads=6, ~4.2M params |
+| Algorithm | Linear flow matching, AdamW, cosine LR |
+
+## Task: Image Generation
+
+The model learns to generate CIFAR-10 images (32×32 RGB) using **flow matching**:
+- Start from Gaussian noise
+- Learn a velocity field that transforms noise → images
+- Sample by integrating the velocity ODE
+
+This is more modern than DDPM and can generate in 10-50 steps instead of 1000.

--- a/src/autoresearch/prepare.py
+++ b/src/autoresearch/prepare.py
@@ -1,0 +1,168 @@
+"""
+prepare.py — READ-ONLY. Do NOT modify this file.
+
+Fixed utilities for the nano-diffusion autoresearch benchmark:
+  - Data loading (CIFAR-10)
+  - Evaluation (val_loss + FID)
+  - Fixed benchmark constants
+
+The agent only modifies train.py.
+"""
+
+import os
+import time
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, random_split
+import torchvision
+import torchvision.transforms as T
+
+# ─── Fixed benchmark constants ────────────────────────────────────────────────
+TIME_BUDGET_SECONDS = 300   # 5-minute training budget per experiment
+DEVICE = "cuda:0"           # single-GPU
+RESOLUTION = 32             # CIFAR-10 image size
+IN_CHANNELS = 3             # RGB
+EVAL_BATCH_SIZE = 512       # batch size for validation loss
+NUM_VAL_BATCHES = 10        # how many batches to use for fast val_loss estimate
+NUM_FID_SAMPLES = 2048      # samples for FID (takes ~60s on Blackwell)
+SEED = 42
+
+
+def get_data_transforms():
+    """Fixed normalization: maps [0,1] -> [-1, 1]."""
+    return T.Compose([
+        T.ToTensor(),
+        T.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+    ])
+
+
+def get_loaders(batch_size: int, random_flip: bool = True, cache_dir: str = None):
+    """Load CIFAR-10 train and val splits.
+
+    Returns
+    -------
+    train_loader, val_loader
+    """
+    if cache_dir is None:
+        cache_dir = os.path.expanduser("~/.cache/torchvision")
+
+    transforms = T.Compose([
+        T.RandomHorizontalFlip() if random_flip else T.Lambda(lambda x: x),
+        T.ToTensor(),
+        T.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+    ])
+    val_transforms = get_data_transforms()
+
+    full = torchvision.datasets.CIFAR10(root=cache_dir, train=True, download=True, transform=transforms)
+    val_ds = torchvision.datasets.CIFAR10(root=cache_dir, train=False, download=True, transform=val_transforms)
+
+    train_loader = DataLoader(full, batch_size=batch_size, shuffle=True,
+                              num_workers=4, pin_memory=True, drop_last=True)
+    val_loader = DataLoader(val_ds, batch_size=EVAL_BATCH_SIZE, shuffle=False,
+                            num_workers=2, pin_memory=True)
+    return train_loader, val_loader
+
+
+@torch.no_grad()
+def evaluate(model, val_loader, device, flow_fn):
+    """Compute validation loss.  This is the primary benchmark metric.
+
+    Parameters
+    ----------
+    model : nn.Module
+        The denoising model (must accept t, x as inputs).
+    val_loader : DataLoader
+        Validation data loader from get_loaders().
+    device : torch.device or str
+    flow_fn : callable
+        A function (model, x1, device) -> loss  — the same loss used in training.
+        Must be deterministic given the same x1 (use a fixed seed inside).
+
+    Returns
+    -------
+    val_loss : float  ← the benchmark metric. Lower is better.
+    """
+    model.eval()
+    total_loss = 0.0
+    count = 0
+    gen = torch.Generator(device='cpu').manual_seed(SEED)
+    for i, (x1, _) in enumerate(val_loader):
+        if i >= NUM_VAL_BATCHES:
+            break
+        x1 = x1.to(device)
+        loss = flow_fn(model, x1, device)
+        total_loss += loss.item()
+        count += 1
+    return total_loss / max(count, 1)
+
+
+def compute_fid(model, sample_fn, device):
+    """Compute FID against CIFAR-10 test set using torch-fidelity.
+
+    Parameters
+    ----------
+    model : nn.Module
+        Trained model.
+    sample_fn : callable
+        A function (model, n, device) -> Tensor(n, 3, 32, 32) in [0, 1].
+    device : str or torch.device
+
+    Returns
+    -------
+    fid : float  or None if torch-fidelity not available
+    """
+    try:
+        import torch_fidelity
+    except ImportError:
+        print("torch-fidelity not installed; skipping FID. Install with: pip install torch-fidelity")
+        return None
+
+    import tempfile
+    from PIL import Image
+    import numpy as np
+
+    cache_dir = os.path.expanduser("~/.cache/torchvision")
+
+    # Generate samples
+    print(f"Generating {NUM_FID_SAMPLES} samples for FID...")
+    t0 = time.time()
+    model.eval()
+    samples = []
+    batch_size = 128
+    with torch.no_grad():
+        for i in range(0, NUM_FID_SAMPLES, batch_size):
+            n = min(batch_size, NUM_FID_SAMPLES - len(samples) * batch_size)
+            if len(samples) * batch_size >= NUM_FID_SAMPLES:
+                break
+            batch = sample_fn(model, batch_size, device)
+            samples.append(batch.cpu())
+    samples = torch.cat(samples, dim=0)[:NUM_FID_SAMPLES]
+    print(f"  Generated {len(samples)} samples in {time.time() - t0:.1f}s")
+
+    # Save to temp dir
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i, img in enumerate(samples):
+            arr = (img.permute(1, 2, 0).clamp(0, 1).numpy() * 255).astype(np.uint8)
+            Image.fromarray(arr).save(os.path.join(tmpdir, f"{i:05d}.png"))
+
+        metrics = torch_fidelity.calculate_metrics(
+            input1=tmpdir,
+            input2="cifar10-train",
+            cuda=True,
+            fid=True,
+            isc=True,
+            verbose=False,
+        )
+
+    fid = metrics.get("frechet_inception_distance", None)
+    isc = metrics.get("inception_score_mean", None)
+    return fid, isc
+
+
+if __name__ == "__main__":
+    print("Preparing CIFAR-10 dataset...")
+    train_loader, val_loader = get_loaders(batch_size=128)
+    print(f"Train batches: {len(train_loader)}, Val batches: {len(val_loader)}")
+    x, y = next(iter(val_loader))
+    print(f"Sample batch: x={x.shape}, range=[{x.min():.2f}, {x.max():.2f}]")
+    print("Done. CIFAR-10 ready.")

--- a/src/autoresearch/program.md
+++ b/src/autoresearch/program.md
@@ -1,0 +1,102 @@
+# nano-diffusion autoresearch
+
+You are an AI research agent running automated experiments on a diffusion model training task.
+
+## The Task
+
+**Goal**: achieve the lowest `val_loss` on CIFAR-10 image generation within a 5-minute training budget.
+
+This is continuous image generation using **flow matching** (a modern alternative to DDPM). The model
+learns to predict a velocity field that transforms Gaussian noise into CIFAR-10 images.
+
+The metric `val_loss` is the MSE between predicted and true velocity, computed on 10 validation
+batches. Lower is better. This is an analogue of `val_bpb` in language models.
+
+## The Rules
+
+1. **You may only modify `train.py`**. This is the only file you edit.
+2. **Do NOT modify `prepare.py`** — it is read-only and contains the fixed evaluation protocol.
+3. The training script runs for exactly 5 minutes (`TIME_BUDGET_SECONDS = 300`).
+4. All else being equal, **simpler is better**. A small improvement with ugly complexity is not worth it.
+   Removing something and getting equal or better results is a great outcome.
+5. If you find a change that hurts results, revert it and try something else.
+
+## What You Can Change
+
+Everything in `train.py` is fair game:
+
+**Architecture:**
+- Model size: hidden dim, depth, number of heads, MLP ratio
+- Patch size (2 or 4 — smaller patch = more tokens = richer representation but slower)
+- Attention variant: standard MHA → flash attention, grouped-query, linear attention
+- Add positional encoding improvements (RoPE, ALiBi)
+- Add normalization changes (RMSNorm instead of LayerNorm)
+- Pre-norm vs post-norm, QK-norm
+- Add gating, mixture-of-experts, etc.
+
+**Training algorithm:**
+- Flow matching path: `linear` (current), `gvp` (trigonometric), `vp` (variance-preserving)
+- Prediction type: velocity (current), noise/epsilon, x0 prediction
+- Loss weighting: uniform time sampling → logit-normal, log-normal, min-SNR weighting
+- Timestep sampling distribution
+
+**Optimizer:**
+- AdamW hyperparameters: beta1, beta2, epsilon, weight decay
+- Learning rate schedule: cosine (current), warmup-stable-decay, constant, linear
+- Gradient clipping value
+- Try Muon optimizer, Lion, 8-bit Adam, etc.
+- Try EMA beta values
+
+**Data:**
+- Batch size (larger = more stable gradients but fewer steps)
+- Data augmentation (RandomHorizontalFlip is current)
+- Add RandAugment, CutMix, Mixup, etc.
+
+**Other:**
+- Mixed precision (torch.autocast for fp16/bf16 — can 2-3x throughput)
+- Compile with torch.compile
+- Gradient accumulation
+
+## Baseline
+
+The baseline `train.py` uses:
+- DiT architecture: hidden=192, depth=6, heads=6, ~4.2M params
+- Linear flow matching (velocity prediction)
+- AdamW, cosine LR, batch=256, 5 min budget
+- **Baseline val_loss: ~0.197**
+- **Baseline FID: ~65** (estimated; run with `COMPUTE_FID=1`)
+
+## Workflow
+
+For each experiment:
+1. Read the current `train.py`
+2. Propose ONE change (or a small set of related changes)
+3. Run: `python train.py` (from the `autoresearch/` directory)
+4. Record: val_loss, FID (if computed), any notes
+5. If val_loss improved: keep the change. If not: revert.
+6. Repeat.
+
+Track results in a table as you go:
+
+| Experiment | Change | val_loss | FID | Notes |
+|-----------|--------|---------|-----|-------|
+| 0 (baseline) | — | 0.197 | ~65 | DiT/6, hidden=192, linear, AdamW |
+| 1 | ... | ... | ... | ... |
+
+## Hardware
+
+- 2× RTX PRO 6000 Blackwell (96GB each). Use `DEVICE = "cuda:0"` or `"cuda:1"`.
+- The machine has PyTorch 2.10.0+cu128 installed.
+- At batch_size=256 with hidden=192, depth=6: ~2,500 steps in 5 min.
+- To disable FID (faster experiments): `COMPUTE_FID=0 python train.py`
+
+## Research Hints
+
+- **Logit-normal time sampling** improved val_loss by ~8% in rectified flow experiments on this codebase.
+- **torch.compile** + bf16 autocast can give 2-3x speedup, enabling 2-3x more steps in the time budget.
+- **Larger batch** (512-1024) with flash attention can improve stability at same step count.
+- **Patch size 4** halves sequence length, allowing deeper models within the same compute.
+- **Weight decay** on all params (including LayerNorm) has historically helped in similar tasks.
+- **GVP path** (trigonometric) had slightly worse FID than linear in preliminary experiments.
+
+Good luck!

--- a/src/autoresearch/train.py
+++ b/src/autoresearch/train.py
@@ -1,0 +1,311 @@
+"""
+train.py — This is the file you modify.
+
+Goal: achieve the lowest val_loss on CIFAR-10 image generation
+within the 5-minute training budget.
+
+Everything in this file is fair game:
+  - Model architecture (size, depth, patch size, attention, ...)
+  - Training algorithm (flow matching, DDPM, rectified flow, ...)
+  - Optimizer (AdamW, Muon, Lion, ...)
+  - Learning rate schedule
+  - Batch size
+  - Data augmentation
+  - Regularization
+
+Do NOT modify prepare.py — it is read-only and contains the fixed evaluation.
+
+After running, this script prints:
+  val_loss: X.XXXX   ← primary benchmark metric (lower is better)
+  fid: XX.XX         ← secondary metric (lower is better)
+  elapsed: XXXs
+
+Baseline (current): val_loss ~0.197, fid ~65, elapsed ~300s
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import time
+import math
+import copy
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from prepare import (
+    get_loaders, evaluate, compute_fid,
+    TIME_BUDGET_SECONDS, DEVICE, RESOLUTION, IN_CHANNELS, SEED,
+)
+
+# ─── Hyperparameters (change freely) ──────────────────────────────────────────
+BATCH_SIZE = 256
+LEARNING_RATE = 3e-4
+WEIGHT_DECAY = 1e-4
+WARMUP_STEPS = 500
+LR_MIN = 2e-5
+USE_EMA = True
+EMA_BETA = 0.999    # effective window ~1000 steps, good for ~3K step runs
+RANDOM_FLIP = True
+# Flow matching path: "linear" | "gvp"
+PATH_TYPE = "linear"
+# ODE steps for sample generation (used for FID)
+SAMPLE_STEPS = 50
+
+
+# ─── Model architecture ────────────────────────────────────────────────────────
+
+def modulate(x, shift, scale):
+    return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(self, hidden_size, freq_dim=256):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(freq_dim, hidden_size), nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size),
+        )
+        self.freq_dim = freq_dim
+
+    def forward(self, t):
+        half = self.freq_dim // 2
+        freqs = torch.exp(
+            -math.log(10000) * torch.arange(half, dtype=torch.float32, device=t.device) / half
+        )
+        emb = t.float().unsqueeze(1) * freqs.unsqueeze(0)
+        emb = torch.cat([emb.cos(), emb.sin()], dim=-1)
+        return self.mlp(emb)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, heads, mlp_ratio=4.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, elementwise_affine=False)
+        self.norm2 = nn.LayerNorm(dim, elementwise_affine=False)
+        self.attn = nn.MultiheadAttention(dim, heads, batch_first=True, bias=True)
+        mlp_dim = int(dim * mlp_ratio)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, mlp_dim), nn.GELU(approximate="tanh"),
+            nn.Linear(mlp_dim, dim),
+        )
+        self.adaLN = nn.Sequential(nn.SiLU(), nn.Linear(dim, 6 * dim, bias=True))
+
+    def forward(self, x, c):
+        s1, sc1, g1, s2, sc2, g2 = self.adaLN(c).chunk(6, dim=-1)
+        xn = modulate(self.norm1(x), s1, sc1)
+        attn_out, _ = self.attn(xn, xn, xn)
+        x = x + g1.unsqueeze(1) * attn_out
+        x = x + g2.unsqueeze(1) * self.mlp(modulate(self.norm2(x), s2, sc2))
+        return x
+
+
+class DiT(nn.Module):
+    """Diffusion Transformer for CIFAR-10 (32×32).
+
+    Default: ~4M params. Good starting point for 5-min training budget.
+    """
+    def __init__(
+        self,
+        img_size=32, patch_size=2, in_ch=3,
+        hidden=192, depth=6, heads=6, mlp_ratio=4.0,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.in_ch = in_ch
+        self.hidden = hidden
+        num_patches = (img_size // patch_size) ** 2
+
+        self.patch_embed = nn.Conv2d(in_ch, hidden, patch_size, stride=patch_size)
+        self.register_buffer("pos_embed", self._sincos2d(img_size // patch_size, hidden))
+
+        self.t_embed = TimestepEmbedder(hidden)
+        self.blocks = nn.ModuleList([DiTBlock(hidden, heads, mlp_ratio) for _ in range(depth)])
+        self.norm_out = nn.LayerNorm(hidden, elementwise_affine=False)
+        self.adaLN_out = nn.Sequential(nn.SiLU(), nn.Linear(hidden, 2 * hidden, bias=True))
+        self.head = nn.Linear(hidden, patch_size * patch_size * in_ch)
+        self._init_weights()
+
+    @staticmethod
+    def _sincos2d(gs, dim):
+        assert dim % 4 == 0
+        omega = torch.arange(dim // 4, dtype=torch.float64) / (dim // 4)
+        omega = 1.0 / (10000 ** omega)
+        g = torch.arange(gs, dtype=torch.float64)
+        y, x = torch.meshgrid(g, g, indexing="ij")
+        px = torch.outer(x.flatten(), omega)
+        py = torch.outer(y.flatten(), omega)
+        embed = torch.cat([px.sin(), px.cos(), py.sin(), py.cos()], dim=1)
+        return embed.float().unsqueeze(0)
+
+    def _init_weights(self):
+        nn.init.zeros_(self.adaLN_out[-1].weight)
+        nn.init.zeros_(self.adaLN_out[-1].bias)
+        nn.init.zeros_(self.head.weight)
+        nn.init.zeros_(self.head.bias)
+
+    def unpatchify(self, x):
+        p = self.patch_size
+        h = w = int(x.shape[1] ** 0.5)
+        x = x.reshape(-1, h, w, p, p, self.in_ch)
+        x = torch.einsum("nhwpqc->nchpwq", x)
+        return x.reshape(-1, self.in_ch, h * p, w * p)
+
+    def forward(self, t, x):
+        x = self.patch_embed(x).flatten(2).transpose(1, 2) + self.pos_embed
+        c = self.t_embed(t)
+        for block in self.blocks:
+            x = block(x, c)
+        shift, scale = self.adaLN_out(c).chunk(2, dim=-1)
+        x = modulate(self.norm_out(x), shift, scale)
+        return self.unpatchify(self.head(x))
+
+
+# ─── Flow matching ─────────────────────────────────────────────────────────────
+
+def linear_path(t, x0, x1):
+    t_ = t.view(-1, 1, 1, 1)
+    return t_ * x1 + (1 - t_) * x0, x1 - x0
+
+
+def gvp_path(t, x0, x1):
+    a = torch.sin(math.pi * t / 2).view(-1, 1, 1, 1)
+    s = torch.cos(math.pi * t / 2).view(-1, 1, 1, 1)
+    da = (math.pi / 2) * torch.cos(math.pi * t / 2).view(-1, 1, 1, 1)
+    ds = -(math.pi / 2) * torch.sin(math.pi * t / 2).view(-1, 1, 1, 1)
+    return a * x1 + s * x0, da * x1 + ds * x0
+
+
+PATH_FNS = {"linear": linear_path, "gvp": gvp_path}
+
+
+def flow_loss(model, x1, device):
+    """Flow matching loss on a batch. Called by evaluate() in prepare.py."""
+    x0 = torch.randn_like(x1)
+    t = torch.rand(x1.shape[0], device=device)
+    xt, ut = PATH_FNS.get(PATH_TYPE, linear_path)(t, x0, x1)
+    vt = model(t=t, x=xt)
+    return ((vt - ut) ** 2).mean()
+
+
+# ─── ODE sampling for FID ──────────────────────────────────────────────────────
+
+@torch.no_grad()
+def sample(model, n, device):
+    """Euler ODE. Returns (n, 3, 32, 32) in [0, 1]."""
+    x = torch.randn(n, IN_CHANNELS, RESOLUTION, RESOLUTION, device=device)
+    dt = 1.0 / SAMPLE_STEPS
+    for i in range(SAMPLE_STEPS):
+        t = torch.full((n,), i * dt, device=device)
+        x = x + model(t=t, x=x) * dt
+    return (x.clamp(-1, 1) + 1) / 2
+
+
+# ─── LR schedule ──────────────────────────────────────────────────────────────
+
+def cosine_lr(step, total_steps, lr_max, lr_min, warmup):
+    if step < warmup:
+        return lr_max * step / max(warmup, 1)
+    p = (step - warmup) / max(total_steps - warmup, 1)
+    return lr_min + 0.5 * (lr_max - lr_min) * (1 + math.cos(math.pi * p))
+
+
+def update_ema(ema, model, beta):
+    with torch.no_grad():
+        for ep, mp in zip(ema.parameters(), model.parameters()):
+            ep.mul_(beta).add_(mp, alpha=1 - beta)
+
+
+# ─── Main training loop ────────────────────────────────────────────────────────
+
+def train():
+    torch.manual_seed(SEED)
+    device = torch.device(DEVICE)
+
+    train_loader, val_loader = get_loaders(BATCH_SIZE, random_flip=RANDOM_FLIP)
+
+    model = DiT(
+        img_size=RESOLUTION, patch_size=2, in_ch=IN_CHANNELS,
+        hidden=192, depth=6, heads=6, mlp_ratio=4.0,
+    ).to(device)
+    ema = copy.deepcopy(model) if USE_EMA else None
+
+    print(f"Parameters: {sum(p.numel() for p in model.parameters()) / 1e6:.2f}M")
+
+    optimizer = optim.AdamW(
+        model.parameters(), lr=LEARNING_RATE, weight_decay=WEIGHT_DECAY,
+        betas=(0.9, 0.99),
+    )
+
+    t_start = time.time()
+    step = 0
+    total_steps_est = 3000   # rough estimate; used for LR schedule only
+    losses = []
+
+    while True:
+        for x1, _ in train_loader:
+            elapsed = time.time() - t_start
+            if elapsed >= TIME_BUDGET_SECONDS:
+                break
+
+            x1 = x1.to(device)
+            lr = cosine_lr(step, total_steps_est, LEARNING_RATE, LR_MIN, WARMUP_STEPS)
+            for g in optimizer.param_groups:
+                g["lr"] = lr
+
+            model.train()
+            optimizer.zero_grad()
+            loss = flow_loss(model, x1, device)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            if USE_EMA:
+                update_ema(ema, model, EMA_BETA)
+
+            losses.append(loss.item())
+            step += 1
+
+            if step % 500 == 0:
+                avg = sum(losses[-100:]) / len(losses[-100:])
+                print(f"  step {step:5d} | loss {avg:.4f} | lr {lr:.2e} | elapsed {elapsed:.0f}s")
+        else:
+            if time.time() - t_start < TIME_BUDGET_SECONDS:
+                continue
+        break
+
+    elapsed = time.time() - t_start
+    print(f"\nTraining done: {step} steps in {elapsed:.0f}s")
+
+    # ─── Evaluation ───────────────────────────────────────────────────────────
+    # Primary: evaluate raw model (and EMA if available)
+    val_loss = evaluate(model, val_loader, device, flow_loss)
+    print(f"\nval_loss: {val_loss:.4f}")
+
+    if USE_EMA:
+        ema_val_loss = evaluate(ema, val_loader, device, flow_loss)
+        print(f"ema_val_loss: {ema_val_loss:.4f}")
+        # Report best of the two
+        best_val = min(val_loss, ema_val_loss)
+        print(f"best_val_loss: {best_val:.4f}")
+        eval_model = ema if ema_val_loss <= val_loss else model
+    else:
+        eval_model = model
+
+    # FID (optional, ~60s)
+    if os.environ.get("COMPUTE_FID", "1") == "1":
+        result = compute_fid(eval_model, sample, device)
+        if result is not None:
+            fid, isc = result
+            print(f"fid: {fid:.2f}")
+            print(f"inception_score: {isc:.2f}")
+    else:
+        print("fid: (skipped)")
+
+    print(f"elapsed: {elapsed:.0f}s")
+    return val_loss
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary

Adds an [autoresearch](https://github.com/karpathy/autoresearch)-style framework to nano-diffusion — an AI agent can autonomously iterate on diffusion model improvements within a fixed compute budget.

- **Task**: CIFAR-10 image generation via flow matching
- **Metric**: `val_loss` (flow MSE on validation set, lower is better) — analogous to `val_bpb` in nanogpt autoresearch
- **Budget**: 5-minute training runs on a single GPU

## Files Added (`src/autoresearch/`)

| File | Editable by agent | Purpose |
|------|-----------------|---------|
| `prepare.py` | NO (locked) | Fixed evaluation protocol: CIFAR-10 loaders, `evaluate()`, `compute_fid()` |
| `train.py` | **YES** | Model + training loop — the only file an agent modifies |
| `program.md` | NO | Agent instructions, research hints, experiment tracking template |
| `README.md` | NO | Human-facing documentation |

## Baseline (validated on RTX PRO 6000 Blackwell)

```
Model:      DiT, hidden=192, depth=6, heads=6, patch_size=2, ~4.2M params
Algorithm:  Linear flow matching (velocity prediction), AdamW, cosine LR, EMA β=0.999
val_loss:   0.1971  (5-min run, ~2,920 steps, batch=256)
```

## How It Works

An AI agent iterates:
1. Read `program.md` + `train.py`
2. Propose ONE change (architecture, optimizer, loss weighting, etc.)
3. Run: `COMPUTE_FID=0 python train.py` (from `src/autoresearch/`)
4. If `val_loss` improved → keep. Else → revert.
5. Repeat.

`prepare.py` is locked so agents cannot accidentally cheat by modifying the evaluation metric.

Research hints in `program.md`: logit-normal time sampling, `torch.compile`+bf16 (2-3× throughput), larger batches, `patch_size=4` for deeper models, GVP vs linear interpolant comparison.